### PR TITLE
Fix remaing reference to casestudies

### DIFF
--- a/bundles/org.dataflowanalysis.examplemodels/build.properties
+++ b/bundles/org.dataflowanalysis.examplemodels/build.properties
@@ -4,5 +4,5 @@ bin.includes = META-INF/,\
                .,\
                src/,\
                models/,\
-               casestudies/
+               scenarios/
                


### PR DESCRIPTION
This PR fixes a remaining reference to `casestudies` that prevents the build from succeeding